### PR TITLE
Remove redundant seed

### DIFF
--- a/src/esostrategy.cc
+++ b/src/esostrategy.cc
@@ -54,7 +54,6 @@ namespace libcmaes
       {
 	std::random_device rd;
 	_uhgen = std::mt19937(rd());
-	_uhgen.seed(static_cast<uint64_t>(time(nullptr)));
 	_uhunif = std::uniform_real_distribution<>(0,1);
       }
   }
@@ -71,7 +70,6 @@ namespace libcmaes
       {
 	std::random_device rd;
 	_uhgen = std::mt19937(rd());
-	_uhgen.seed(static_cast<uint64_t>(time(nullptr)));
 	_uhunif = std::uniform_real_distribution<>(0,1);
       }
   }


### PR DESCRIPTION
I believe those seed commands are unnecessary after the constructor with random device.
Moreover, this only causes that seeding in the same second will produce the same number.