### PR TITLE
Fixed deprecated EigenMultivariateNormal and bumped cmake version

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,22 @@
+﻿---
+BasedOnStyle: LLVM
+AlignConsecutiveAssignments: 'true'
+AlignEscapedNewlines: Right
+AlignTrailingComments: 'true'
+AllowAllConstructorInitializersOnNextLine: 'false'
+AllowAllParametersOfDeclarationOnNextLine: 'false'
+AllowShortCaseLabelsOnASingleLine: 'true'
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: 'false'
+BinPackArguments: 'false'
+BinPackParameters: 'false'
+BreakBeforeBraces: Allman
+BreakConstructorInitializers: BeforeComma
+CompactNamespaces: 'false'
+ConstructorInitializerAllOnOneLineOrOnePerLine: 'true'
+IndentWidth: '2'
+Language: Cpp
+TabWidth: '2'
+
+...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.1)
 
-project (libcmaes VERSION 0.9.7.0 LANGUAGES C CXX)
+project (libcmaes VERSION 0.9.8.1 LANGUAGES C CXX)
 
 if (NOT DEFINED CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")
@@ -190,3 +190,7 @@ install (
         "${CMAKE_CURRENT_BINARY_DIR}/libcmaesConfigVersion.cmake"
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindEigen3.cmake"
   DESTINATION ${RELATIVE_INSTALL_CMAKE_DIR})
+
+if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  export(PACKAGE libcmaes)
+endif()

--- a/include/libcmaes/eigenmvn.h
+++ b/include/libcmaes/eigenmvn.h
@@ -1,20 +1,25 @@
 /**
  * Multivariate Normal distribution sampling using C++11 and Eigen matrices.
- * 
- * This is taken from http://stackoverflow.com/questions/16361226/error-while-creating-object-from-templated-class
- * (also see http://lost-found-wandering.blogspot.fr/2011/05/sampling-from-multivariate-normal-in-c.html)
- * 
+ *
+ * This is taken from
+ * http://stackoverflow.com/questions/16361226/error-while-creating-object-from-templated-class
+ * (also see
+ * http://lost-found-wandering.blogspot.fr/2011/05/sampling-from-multivariate-normal-in-c.html)
+ *
  * I have been unable to contact the original author, and I've performed
  * the following modifications to the original code:
  * - removal of the dependency to Boost, in favor of straight C++11;
- * - ability to choose from Solver or Cholesky decomposition (supposedly faster);
- * - fixed Cholesky by using LLT decomposition instead of LDLT that was not yielding
- *   a correctly rotated variance 
- *   (see this http://stats.stackexchange.com/questions/48749/how-to-sample-from-a-multivariate-normal-given-the-pt-ldlt-p-decomposition-o )
+ * - ability to choose from Solver or Cholesky decomposition (supposedly
+ * faster);
+ * - fixed Cholesky by using LLT decomposition instead of LDLT that was not
+ * yielding a correctly rotated variance (see this
+ * http://stats.stackexchange.com/questions/48749/how-to-sample-from-a-multivariate-normal-given-the-pt-ldlt-p-decomposition-o
+ * )
  */
 
 /**
- * Copyright (c) 2014 by Emmanuel Benazera beniz@droidnik.fr, All rights reserved.
+ * Copyright (c) 2014 by Emmanuel Benazera beniz@droidnik.fr, All rights
+ * reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -25,7 +30,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library.
  */
@@ -39,128 +44,174 @@
 
 /*
   We need a functor that can pretend it's const,
-  but to be a good random number generator 
-  it needs mutable state.  The standard Eigen function 
+  but to be a good random number generator
+  it needs mutable state.  The standard Eigen function
   Random() just calls rand(), which changes a global
   variable.
 */
 namespace Eigen {
-  namespace internal {
-    template<typename Scalar>
-      struct scalar_normal_dist_op
-      {
-	static std::mt19937 rng;                        // The uniform pseudo-random algorithm
-	mutable std::normal_distribution<Scalar> norm; // gaussian combinator
-	
-	EIGEN_EMPTY_STRUCT_CTOR(scalar_normal_dist_op)
+namespace internal {
+template <typename Scalar> struct scalar_normal_dist_op {
+  static std::mt19937 rng; // The uniform pseudo-random algorithm
+  mutable std::normal_distribution<Scalar> norm; // gaussian combinator
 
-	template<typename Index>
-	inline const Scalar operator() (Index, Index = 0) const { return norm(rng); }
-	inline void seed(const uint64_t &s) { rng.seed(s); }
-      };
+  EIGEN_EMPTY_STRUCT_CTOR(scalar_normal_dist_op)
 
-    template<typename Scalar>
-      std::mt19937 scalar_normal_dist_op<Scalar>::rng;
-      
-    template<typename Scalar>
-      struct functor_traits<scalar_normal_dist_op<Scalar> >
-      { enum { Cost = 50 * NumTraits<Scalar>::MulCost, PacketAccess = false, IsRepeatable = false }; };
-    
-  } // end namespace internal
+  template <typename Index>
+  inline const Scalar operator()(Index, Index = 0) const {
+    return norm(rng);
+  }
+  inline void seed(const uint64_t &s) { rng.seed(s); }
+};
 
-  /**
-    Find the eigen-decomposition of the covariance matrix
-    and then store it for sampling from a multi-variate normal 
-  */
-  template<typename Scalar>
-    class EigenMultivariateNormal
-  {
-    Matrix< Scalar, Dynamic, 1> _mean;
-    internal::scalar_normal_dist_op<Scalar> randN; // Gaussian functor
-    bool _use_cholesky;
+template <typename Scalar> std::mt19937 scalar_normal_dist_op<Scalar>::rng;
 
-  public:
-    void set_covar(const Matrix<Scalar,Dynamic,Dynamic> &covar) { _covar = covar; }
-    void set_transform(const Matrix<Scalar,Dynamic,Dynamic> &transform) { _transform = transform; }
-    
-  private:
-    Matrix<Scalar,Dynamic,Dynamic> _covar;
-    Matrix<Scalar,Dynamic,Dynamic> _transform;
-    
-  public:
-    SelfAdjointEigenSolver<Matrix<Scalar,Dynamic,Dynamic> > _eigenSolver; // drawback: this creates a useless eigenSolver when using Cholesky decomposition, but it yields access to eigenvalues and vectors
-    
-  public:
-    EigenMultivariateNormal(const bool &use_cholesky=false,
-			    const uint64_t &seed=std::mt19937::default_seed)
-      :_use_cholesky(use_cholesky)
-      {
-	randN.seed(seed);
-      }
-  EigenMultivariateNormal(const Matrix<Scalar,Dynamic,1>& mean,const Matrix<Scalar,Dynamic,Dynamic>& covar,
-			  const bool &use_cholesky=false,const uint64_t &seed=std::mt19937::default_seed)
-      :_use_cholesky(use_cholesky)
-    {
-      randN.seed(seed);
-      setMean(mean);
-      setCovar(covar);
+template <typename Scalar>
+struct functor_traits<scalar_normal_dist_op<Scalar>> {
+  enum {
+    Cost = 50 * NumTraits<Scalar>::MulCost,
+    PacketAccess = false,
+    IsRepeatable = false
+  };
+};
+
+} // end namespace internal
+
+/**
+  Find the eigen-decomposition of the covariance matrix
+  and then store it for sampling from a multi-variate normal
+*/
+template <typename Scalar> class EigenMultivariateNormal {
+  Matrix<Scalar, Dynamic, 1> _mean;
+  internal::scalar_normal_dist_op<Scalar> randN; // Gaussian functor
+  bool _use_cholesky;
+
+public:
+  void set_covar(const Matrix<Scalar, Dynamic, Dynamic> &covar) {
+    _covar = covar;
+  }
+  void set_transform(const Matrix<Scalar, Dynamic, Dynamic> &transform) {
+    _transform = transform;
+  }
+
+private:
+  Matrix<Scalar, Dynamic, Dynamic> _covar;
+  Matrix<Scalar, Dynamic, Dynamic> _transform;
+
+public:
+  SelfAdjointEigenSolver<Matrix<Scalar, Dynamic, Dynamic>>
+      _eigenSolver; // drawback: this creates a useless eigenSolver when using
+                    // Cholesky decomposition, but it yields access to
+                    // eigenvalues and vectors
+
+private:
+  void swap(EigenMultivariateNormal &other) {
+    std::swap(_mean, other._mean);
+    std::swap(randN, other.randN);
+    std::swap(_use_cholesky, other._use_cholesky);
+
+    std::swap(_covar, other._covar);
+    std::swap(_transform, other._transform);
+
+    std::swap(_eigenSolver, other._eigenSolver);
+  }
+
+public:
+  EigenMultivariateNormal(const bool &use_cholesky = false,
+                          const uint64_t &seed = std::mt19937::default_seed)
+      : _use_cholesky(use_cholesky) {
+    randN.seed(seed);
+  }
+  EigenMultivariateNormal(const Matrix<Scalar, Dynamic, 1> &mean,
+                          const Matrix<Scalar, Dynamic, Dynamic> &covar,
+                          const bool &use_cholesky = false,
+                          const uint64_t &seed = std::mt19937::default_seed)
+      : _use_cholesky(use_cholesky) {
+    randN.seed(seed);
+    setMean(mean);
+    setCovar(covar);
+  }
+
+  EigenMultivariateNormal(const EigenMultivariateNormal &other) {
+    _mean = other._mean;
+
+    randN.rng = other.randN.rng;
+    randN.norm = other.randN.norm;
+
+    _use_cholesky = other._use_cholesky;
+    _covar = other._covar;
+    _transform = other._transform;
+    _eigenSolver = other._eigenSolver;
+  }
+  EigenMultivariateNormal &operator=(const EigenMultivariateNormal &other) {
+    EigenMultivariateNormal temp(other);
+    swap(temp);
+    return *this;
+  }
+  EigenMultivariateNormal(EigenMultivariateNormal &&other) {
+    *this = std::move(other);
+  }
+  EigenMultivariateNormal &operator=(EigenMultivariateNormal &&other) {
+    if (this != &other) {
+      swap(other);
     }
+    return *this;
+  }
 
-    void setMean(const Matrix<Scalar,Dynamic,1>& mean) { _mean = mean; }
-    void setCovar(const Matrix<Scalar,Dynamic,Dynamic>& covar)
-    {
-      _covar = covar;
-      
-      // Assuming that we'll be using this repeatedly,
-      // compute the transformation matrix that will
-      // be applied to unit-variance independent normals
-      
-      if (_use_cholesky)
-	{
-	  Eigen::LLT<Eigen::Matrix<Scalar,Dynamic,Dynamic> > cholSolver(_covar);
-	  // We can only use the cholesky decomposition if 
-	  // the covariance matrix is symmetric, pos-definite.
-	  // But a covariance matrix might be pos-semi-definite.
-	  // In that case, we'll go to an EigenSolver
-	  if (cholSolver.info()==Eigen::Success)
-	    {
-	      // Use cholesky solver
-	      _transform = cholSolver.matrixL();
-	    }
-	  else
-	    {
-	      throw std::runtime_error("Failed computing the Cholesky decomposition. Use solver instead");
-	    }
-	}
-      else
-	{
-	  _eigenSolver = SelfAdjointEigenSolver<Matrix<Scalar,Dynamic,Dynamic> >(_covar);
-	  _transform = _eigenSolver.eigenvectors()*_eigenSolver.eigenvalues().cwiseMax(0).cwiseSqrt().asDiagonal();
-	}
+  void setMean(const Matrix<Scalar, Dynamic, 1> &mean) { _mean = mean; }
+  void setCovar(const Matrix<Scalar, Dynamic, Dynamic> &covar) {
+    _covar = covar;
+
+    // Assuming that we'll be using this repeatedly,
+    // compute the transformation matrix that will
+    // be applied to unit-variance independent normals
+
+    if (_use_cholesky) {
+      Eigen::LLT<Eigen::Matrix<Scalar, Dynamic, Dynamic>> cholSolver(_covar);
+      // We can only use the cholesky decomposition if
+      // the covariance matrix is symmetric, pos-definite.
+      // But a covariance matrix might be pos-semi-definite.
+      // In that case, we'll go to an EigenSolver
+      if (cholSolver.info() == Eigen::Success) {
+        // Use cholesky solver
+        _transform = cholSolver.matrixL();
+      } else {
+        throw std::runtime_error(
+            "Failed computing the Cholesky decomposition. Use solver instead");
+      }
+    } else {
+      _eigenSolver =
+          SelfAdjointEigenSolver<Matrix<Scalar, Dynamic, Dynamic>>(_covar);
+      _transform =
+          _eigenSolver.eigenvectors() *
+          _eigenSolver.eigenvalues().cwiseMax(0).cwiseSqrt().asDiagonal();
     }
+  }
 
-    /// Draw nn samples from the gaussian and return them
-    /// as columns in a Dynamic by nn matrix
-    Matrix<Scalar,Dynamic,-1> samples(int nn, double factor)
-      {
-	return ((_transform * Matrix<Scalar,Dynamic,-1>::NullaryExpr(_covar.rows(),nn,randN))*factor).colwise() + _mean;
-      }
+  /// Draw nn samples from the gaussian and return them
+  /// as columns in a Dynamic by nn matrix
+  Matrix<Scalar, Dynamic, -1> samples(int nn, double factor) {
+    return ((_transform * Matrix<Scalar, Dynamic, -1>::NullaryExpr(
+                              _covar.rows(), nn, randN)) *
+            factor)
+               .colwise() +
+           _mean;
+  }
 
-    Matrix<Scalar,Dynamic,-1> samples_ind(int nn, double factor)
-      {
-	dMat pop = (Matrix<Scalar,Dynamic,-1>::NullaryExpr(_covar.rows(),nn,randN))*factor;
-	for (int i=0;i<pop.cols();i++)
-	  {
-	    pop.col(i) = pop.col(i).cwiseProduct(_transform) + _mean;
-	  }
-	return pop;
-      }
+  Matrix<Scalar, Dynamic, -1> samples_ind(int nn, double factor) {
+    dMat pop =
+        (Matrix<Scalar, Dynamic, -1>::NullaryExpr(_covar.rows(), nn, randN)) *
+        factor;
+    for (int i = 0; i < pop.cols(); i++) {
+      pop.col(i) = pop.col(i).cwiseProduct(_transform) + _mean;
+    }
+    return pop;
+  }
 
-    Matrix<Scalar,Dynamic,-1> samples_ind(int nn)
-      {
-	return (Matrix<Scalar,Dynamic,-1>::NullaryExpr(_covar.rows(),nn,randN));
-      }
-    
-  }; // end class EigenMultivariateNormal
+  Matrix<Scalar, Dynamic, -1> samples_ind(int nn) {
+    return (Matrix<Scalar, Dynamic, -1>::NullaryExpr(_covar.rows(), nn, randN));
+  }
+
+}; // end class EigenMultivariateNormal
 } // end namespace Eigen
 #endif


### PR DESCRIPTION
- Included rule of 5 copy/move constructor for EigenMultivariateNormal
- Bumped version to 0.9.8.1 (The 0.9.8 release did not have a cmake version increased. I took the freedom to bump it to 0.9.8.1 for cmake finds, feel free to revert it to 0.9.8.0 if you do not like that.)
- The export as a cmake package did not work properly. I added the missing part and now find_package(libcmaes REQUIRED) works.

Closes #225 

