### PR TITLE
Fixed the cmake compile options to not override parent project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,13 @@ if (NOT DEFINED CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")
 endif ()
 
-set(CMAKE_CXX_FLAGS "-Wall -Wextra")
-set(CMAKE_CXX_FLAGS_DEBUG "-g")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+add_compile_options(
+  -Wall
+  -Wextra
+  "$<$<CONFIG:RELEASE>:-O3>"
+  "$<$<CONFIG:DEBUG>:-g>"
+  )
+
 
 list (APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 


### PR DESCRIPTION
@beniz  @nikohansen 
In https://github.com/phbasler/BSMPT/issues/72 we noticed some issues with including cmaes as a submodule in a larger CMake project. 
The old way to set CMAKE_CXX_FLAGS(_DEBUG/_RELEASE) overwrote the flags set by the parent project, which in our case led to a runtime crash. 
After adjusting it locally to the proposed change, it works as expected.