### PR TITLE
Update runner on doxygen workflow

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -12,9 +12,9 @@ on:
     
 jobs:
   Deploy:
-     runs-on: ubuntu-20.04
+     runs-on: ubuntu-latest
      steps:
-     - uses: actions/checkout@v2
+     - uses: actions/checkout@v4
        with:
           persist-credentials: false
      - name: installPackages


### PR DESCRIPTION
The doxygen workflow does not run because it has ubuntu-20.04 fixed. This runner is deprecated and the update to latest is necessary.

Also updated the checkout action from v2 to v4.